### PR TITLE
Fix Elixir 1.4.0 compiler warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,12 +6,12 @@ defmodule Strava.Mixfile do
      version: "0.3.1",
      elixir: "~> 1.3",
      name: "Strava",
-     description: description,
-     package: package,
+     description: description(),
+     package: package(),
      source_url: "https://github.com/slashdotdash/strava",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do

--- a/test/strava/auth_test.exs
+++ b/test/strava/auth_test.exs
@@ -12,7 +12,7 @@ defmodule Strava.AuthTest do
   end
 
   test "get athlete from access token" do
-    athlete = Strava.Auth.get_athlete!(access_token)
+    athlete = Strava.Auth.get_athlete!(access_token())
 
     assert athlete.id == 227615
     assert athlete.firstname == "John"


### PR DESCRIPTION
Just a quick fix to get rid of warnings while I was making the other change.