### PR TITLE
Add username field to DetailedAthlete model

### DIFF
--- a/lib/strava/model/detailed_athlete.ex
+++ b/lib/strava/model/detailed_athlete.ex
@@ -6,6 +6,7 @@ defmodule Strava.DetailedAthlete do
   @derive [Poison.Encoder]
   defstruct [
     :id,
+    :username,
     :resource_state,
     :firstname,
     :lastname,
@@ -35,6 +36,7 @@ defmodule Strava.DetailedAthlete do
 
   @type t :: %__MODULE__{
           id: integer(),
+          username: String.t(),
           resource_state: integer(),
           firstname: String.t(),
           lastname: String.t(),


### PR DESCRIPTION
There was a missing field on the DetailedAthlete model, this commits add the `username` field to this model.

On master:
```elixir
[error] #PID<0.1510.0> running AthletisticWeb.Endpoint (connection #PID<0.1507.0>, stream id 2) terminated
Server: localhost:4000 (http)
Request: GET /sessions/callback?state=&code=d0a2e1d4c832d75445e9ce0e38376a81277ad90d&scope=read,activity:read_all
** (exit) an exception was raised:
    ** (KeyError) key :username not found in: %Strava.DetailedAthlete{bikes: nil, city: nil, clubs: nil, country: nil, created_at: ~U[2016-05-27 10:30:53Z], email: nil, firstname: "Robert", follower: nil, follower_count: nil, friend: nil, friend_count: nil, ftp: nil, id: 15449014, lastname: "Korzeniec", measurement_preference: nil, mutual_friend_count: nil, premium: false, profile: "https://d3nn82uaxijpm6.cloudfront.net/assets/avatar/athlete/large-800a7033cc92b2a5548399e26b1ef42414dd1a9cb13b99454222d38d58fd28ef.png", profile_medium: "https://d3nn82uaxijpm6.cloudfront.net/assets/avatar/athlete/medium-bee27e393b8559be0995b6573bcfde897d6af934dac8f392a6229295290e16dd.png", resource_state: 2, sex: "M", shoes: nil, state: nil, summit: false, updated_at: ~U[2020-12-12 16:51:35Z], weight: nil}
        (athletistic 0.1.0) lib/athletistic_web/controllers/session_controller.ex:33: AthletisticWeb.SessionController.handle_success/2
        (athletistic 0.1.0) lib/athletistic_web/controllers/session_controller.ex:3: AthletisticWeb.SessionController.action/2
        (athletistic 0.1.0) lib/athletistic_web/controllers/session_controller.ex:3: AthletisticWeb.SessionController.phoenix_controller_pipeline/2
        (phoenix 1.5.7) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (athletistic 0.1.0) lib/athletistic_web/endpoint.ex:1: AthletisticWeb.Endpoint.plug_builder_call/2
        (athletistic 0.1.0) lib/plug/debugger.ex:132: AthletisticWeb.Endpoint."call (overridable 3)"/2
        (athletistic 0.1.0) lib/athletistic_web/endpoint.ex:1: AthletisticWeb.Endpoint.call/2
        (phoenix 1.5.7) lib/phoenix/endpoint/cowboy2_handler.ex:65: Phoenix.Endpoint.Cowboy2Handler.init/4
        (cowboy 2.8.0) /Users/robertkorzeniec/development/personal/phoenix/athletistic/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
        (cowboy 2.8.0) /Users/robertkorzeniec/development/personal/phoenix/athletistic/deps/cowboy/src/cowboy_stream_h.erl:300: :cowboy_stream_h.execute/3
        (cowboy 2.8.0) /Users/robertkorzeniec/development/personal/phoenix/athletistic/deps/cowboy/src/cowboy_stream_h.erl:291: :cowboy_stream_h.request_process/3
        (stdlib 3.13.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```
Where as on this branch it is OK 