### PR TITLE
Fix refresh_token middleware retry

### DIFF
--- a/lib/strava/middleware/refresh_token.ex
+++ b/lib/strava/middleware/refresh_token.ex
@@ -11,7 +11,7 @@ defmodule Strava.Middleware.RefreshToken do
   def call(env, next, opts) do
     refresh_token = Keyword.get(opts, :refresh_token)
 
-    with {:ok, %Tesla.Env{status: 401} = env} <- Tesla.run(env, next),
+    with {:ok, %Tesla.Env{status: 401}} <- Tesla.run(env, next),
          {:ok, %Tesla.Env{} = env} <- attempt_refresh_token(env, refresh_token, opts) do
       # Retry request with refreshed access token
       Tesla.run(env, next)

--- a/test/strava/client_test.exs
+++ b/test/strava/client_test.exs
@@ -1,0 +1,13 @@
+defmodule Strava.ClientTest do
+  use ExUnit.Case, async: false
+
+  describe "refresh_token middleware" do
+    test "retries the failed request" do
+      access_token = "abcd1234" # invalid/expired access token
+
+      client = Strava.Client.new(access_token, refresh_token: Strava.refresh_token())
+
+      {:ok, %Strava.DetailedAthlete{}} = Strava.Athletes.get_logged_in_athlete(client)
+    end
+  end
+end


### PR DESCRIPTION
We were overriding the original Tesla.env with the response from the failed request. The failed request already had a status (401) and a body (json containing Authorization Error).

This change keeps the original Tesla.env and only updates the authorization header after using the refresh_token.

Let me know what you think about the tests. I wasn't sure how to test just the middleware so I wrote a test for the client instead.